### PR TITLE
feature/beperkingveld

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use App\Models\Event;
 use App\Models\Group;
+use function PHPUnit\Framework\isEmpty;
 
 class EventController extends Controller
 {
@@ -76,9 +77,6 @@ class EventController extends Controller
         } catch (\Exception $e) {
             return redirect('/evenement')->with('error', 'Evenement niet gevonden.');
         }
-
-
-
     }
 
     public function enroll(int $id)
@@ -88,11 +86,23 @@ class EventController extends Controller
 
     public function submit(MailPostEventRequest $request)
     {
-        $validated = $request->validated();
-
+        $request->validate([
+            'name' => 'required|max:255',
+            'birthday' => 'required|date|before:today',
+            'disability' => 'max:255',
+            'email' => 'required|email',
+            'phonenumber' => 'required|numeric',
+            'address' => 'required|max:255',
+            'city' => 'required|max:255',
+            'event_id' => 'required|numeric'
+        ]);
         $mailFactory = new MailFactory();
+        $disability = "Niet ingevoerd";
+        if(isset($request['disability']) && !isEmpty($request['disability'])){
+            $disability = $request['disability'];
+        }
         $mail = $mailFactory->createMail('eventRegistration',
-            ['name' => $request['name'], 'birthday' => $request['birthday'], 'email' => $request['email'], 'phonenumber' => $request['phonenumber'], 'address' => $request['address'], 'city' => $request['city'], 'disability' => $request['disability'], 'event_id' => $request['event_id']]);
+            ['name' => $request['name'], 'birthday' => $request['birthday'], 'email' => $request['email'], 'phonenumber' => $request['phonenumber'], 'address' => $request['address'], 'city' => $request['city'], 'disability' => $disability, 'event_id' => $request['event_id']]);
         Mailer::Mail([], $mail, true);
         return redirect('evenement')->with('success', 'Uw aanmelding is verzonden!');
     }

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -89,7 +89,7 @@ class EventController extends Controller
         $request->validate([
             'name' => 'required|max:255',
             'birthday' => 'required|date|before:today',
-            'disability' => 'max:255',
+            'golfhandicap' => 'max:255',
             'email' => 'required|email',
             'phonenumber' => 'required|numeric',
             'address' => 'required|max:255',
@@ -97,12 +97,12 @@ class EventController extends Controller
             'event_id' => 'required|numeric'
         ]);
         $mailFactory = new MailFactory();
-        $disability = "Niet ingevoerd";
-        if(isset($request['disability']) && !isEmpty($request['disability'])){
-            $disability = $request['disability'];
+        $golfhandicap = "Niet ingevoerd";
+        if(isset($request['golfhandicap']) && !empty($request['golfhandicap'])){
+            $golfhandicap = $request['golfhandicap'];
         }
         $mail = $mailFactory->createMail('eventRegistration',
-            ['name' => $request['name'], 'birthday' => $request['birthday'], 'email' => $request['email'], 'phonenumber' => $request['phonenumber'], 'address' => $request['address'], 'city' => $request['city'], 'disability' => $disability, 'event_id' => $request['event_id']]);
+            ['name' => $request['name'], 'birthday' => $request['birthday'], 'email' => $request['email'], 'phonenumber' => $request['phonenumber'], 'address' => $request['address'], 'city' => $request['city'], 'golfhandicap' => $golfhandicap, 'event_id' => $request['event_id']]);
         Mailer::Mail([], $mail, true);
         return redirect('evenement')->with('success', 'Uw aanmelding is verzonden!');
     }

--- a/app/Http/Requests/MailPostEventRequest.php
+++ b/app/Http/Requests/MailPostEventRequest.php
@@ -28,7 +28,7 @@ class MailPostEventRequest extends FormRequest
             'phonenumber' => 'required|regex:/^([0-9\s\-\+\(\)]*)$/|min:10|max:255',
             'address' => 'required|max:255',
             'city' => 'required|max:255',
-            'disability' => 'nullable|max:255',
+            'golfhandicap' => 'nullable|max:255',
             'event_id' => 'required|numeric'
         ];
     }
@@ -50,7 +50,7 @@ class MailPostEventRequest extends FormRequest
             'address.max' => 'Uw adres mag niet langer zijn dan 255 karakters',
             'city.required' => 'Uw woonplaats is verplicht',
             'city.max' => 'De naam van uw woonplaats mag niet langer zijn dan 255 karakters',
-            'disability.max' => 'De beschrijving van uw beperking mag niet langer zijn dan 255 karakters',
+            'golfhandicap.max' => 'De beschrijving van uw beperking mag niet langer zijn dan 255 karakters',
         ];
     }
 }

--- a/app/Http/Requests/MailPostEventRequest.php
+++ b/app/Http/Requests/MailPostEventRequest.php
@@ -28,7 +28,7 @@ class MailPostEventRequest extends FormRequest
             'phonenumber' => 'required|regex:/^([0-9\s\-\+\(\)]*)$/|min:10|max:255',
             'address' => 'required|max:255',
             'city' => 'required|max:255',
-            'disability' => 'required|max:255',
+            'disability' => 'nullable|max:255',
             'event_id' => 'required|numeric'
         ];
     }
@@ -50,7 +50,6 @@ class MailPostEventRequest extends FormRequest
             'address.max' => 'Uw adres mag niet langer zijn dan 255 karakters',
             'city.required' => 'Uw woonplaats is verplicht',
             'city.max' => 'De naam van uw woonplaats mag niet langer zijn dan 255 karakters',
-            'disability.required' => 'Het invoeren van de beperking is verplicht',
             'disability.max' => 'De beschrijving van uw beperking mag niet langer zijn dan 255 karakters',
         ];
     }

--- a/app/Models/Mail/MailFactory.php
+++ b/app/Models/Mail/MailFactory.php
@@ -51,7 +51,7 @@ class MailFactory
             $arguments['phonenumber'] == null ||
             $arguments['address'] == null ||
             $arguments['city'] == null ||
-            $arguments['disability'] == null ||
+            $arguments['golfhandicap'] == null ||
             $arguments['event_id'] == null
         ){
             throw new InvalidArgumentException('niet alle argumenten waren gevonden');
@@ -63,7 +63,7 @@ class MailFactory
         $phonenumber = $arguments['phonenumber'];
         $address = $arguments['address'];
         $city = $arguments['city'];
-        $disability = $arguments['disability'];
+        $golfhandicap = $arguments['golfhandicap'];
         $eventId = $arguments['event_id'];
         $event = Event::find($eventId) ?: throw new InvalidArgumentException('evenement is niet gevonden');
         $age = date_diff(date_create($birthday), date_create(date('Y-m-d')))->format('%y');
@@ -73,14 +73,14 @@ class MailFactory
         }
 
         $text = 'hallo '.$name;
-        $mail = new Mail\RegisterMail($name,$age,$email,$phonenumber,$address,$city,$disability,$event->title,$event->date);
+        $mail = new Mail\RegisterMail($name,$age,$email,$phonenumber,$address,$city,$golfhandicap,$event->title,$event->date);
         return $mail;
     }
 
     private function trainingSignout($arguments) : Mailable
     {
         if($arguments['name'] == null ||
-            $arguments['date'] == null 
+            $arguments['date'] == null
         ){
             throw new InvalidArgumentException('niet alle argumenten waren gevonden');
         }

--- a/app/Models/Mail/RegisterMail.php
+++ b/app/Models/Mail/RegisterMail.php
@@ -18,14 +18,14 @@ class RegisterMail extends Mailable
     public $phonenumber;
     public $address;
     public $city;
-    public $disability;
+    public $golfhandicap;
     public $eventName;
     public $date;
 
     /**
      * Create a new message instance.
      */
-    public function __construct($name, $age, $email, $phonenumber, $address, $city, $disability, $eventName, $date)
+    public function __construct($name, $age, $email, $phonenumber, $address, $city, $golfhandicap, $eventName, $date)
     {
         $this->name = $name;
         $this->age = $age;
@@ -33,7 +33,7 @@ class RegisterMail extends Mailable
         $this->phonenumber = $phonenumber;
         $this->address = $address;
         $this->city = $city;
-        $this->disability = $disability;
+        $this->golfhandicap = $golfhandicap;
         $this->eventName = $eventName;
         $this->date = $date;
     }

--- a/resources/views/emails/registrationmail.blade.php
+++ b/resources/views/emails/registrationmail.blade.php
@@ -70,10 +70,10 @@
         </tr>
         <tr>
             <td>
-                Beperking:
+                Golfhandicap:
             </td>
             <td>
-                {{$disability}}
+                {{$golfhandicap}}
             </td>
         </tr>
     </table>

--- a/resources/views/events/aanmelden.blade.php
+++ b/resources/views/events/aanmelden.blade.php
@@ -42,14 +42,14 @@
                         @enderror
                     </div>
                     <div>
-                        <label for="disability" class="col-sm-2 col-form-label">
-                            Spelershandicap
+                        <label for="golfhandicap" class="col-sm-2 col-form-label">
+                            Golfhandicap
                         </label>
                         <div class="col-sm-8">
-                            <input type="text" class="form-control" id="disability"
-                            placeholder="Vul hier uw verstandelijke beperking(en) in" name="disability"  value="{{old('disability')}}">
+                            <input type="text" class="form-control" id="golfhandicap"
+                            placeholder="Vul hier uw golfhandicap(s) in" name="golfhandicap" value="{{old('golfhandicap')}}">
                         </div>
-                        @error('disability')
+                        @error('golfhandicap')
                         <div class="alert alert-danger">{{ $message }}</div>
                         @enderror
                     </div>

--- a/resources/views/events/aanmelden.blade.php
+++ b/resources/views/events/aanmelden.blade.php
@@ -43,7 +43,7 @@
                     </div>
                     <div>
                         <label for="disability" class="col-sm-2 col-form-label">
-                            <span class="requiredStar">*</span>Beperking
+                            Spelershandicap
                         </label>
                         <div class="col-sm-8">
                             <input type="text" class="form-control" id="disability"

--- a/tests/Browser/EnrollForEventTest.php
+++ b/tests/Browser/EnrollForEventTest.php
@@ -20,7 +20,9 @@ class EnrollForEventTest extends DuskTestCase
                 ->type('phonenumber', '0612345678')
                 ->type('address', 'Teststraat 1')
                 ->type('city', 'Teststad')
-                ->type('disability', 'Geen')
+                ->type('golfhandicap', 'Geen');
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
                 ->press('#aanmeldknop')
                 ->assertSee('Uw aanmelding is verzonden!');
         });
@@ -43,7 +45,10 @@ class EnrollForEventTest extends DuskTestCase
                 ->type('phonenumber', '0612345678')
                 ->type('address', 'Teststraat 1')
                 ->type('city', 'Teststad')
-                ->type('disability', 'Geen')
+                ->type('golfhandicap', 'Geen')
+                ->maximize();
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
                 ->press('#aanmeldknop')
                 ->assertDontSee('Uw aanmelding is verzonden!');
 
@@ -56,7 +61,10 @@ class EnrollForEventTest extends DuskTestCase
                 ->type('phonenumber', '0612345678')
                 ->type('address', 'Teststraat 1')
                 ->type('city', 'Teststad')
-                ->type('disability', 'Geen')
+                ->type('golfhandicap', 'Geen')
+                ->maximize();
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
                 ->press('#aanmeldknop')
                 ->assertDontSee('Uw aanmelding is verzonden!');
         });
@@ -74,7 +82,10 @@ class EnrollForEventTest extends DuskTestCase
                 ->type('phonenumber', '0612345678')
                 ->type('address', 'Teststraat 1')
                 ->type('city', 'Teststad')
-                ->type('disability', 'Geen')
+                ->type('golfhandicap', 'Geen')
+                ->maximize();
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
                 ->press('#aanmeldknop')
                 ->assertDontSee('Uw aanmelding is verzonden!');
 
@@ -87,7 +98,10 @@ class EnrollForEventTest extends DuskTestCase
                 ->type('phonenumber', '0612345678')
                 ->type('address', 'Teststraat 1')
                 ->type('city', 'Teststad')
-                ->type('disability', 'Geen')
+                ->type('golfhandicap', 'Geen')
+                ->maximize();
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
                 ->press('#aanmeldknop')
                 ->assertDontSee('Uw aanmelding is verzonden!');
         });
@@ -110,7 +124,10 @@ class EnrollForEventTest extends DuskTestCase
                 ->type('phonenumber', '0612345678')
                 ->type('address', 'Teststraat 1')
                 ->type('city', 'Teststad')
-                ->type('disability', 'Geen')
+                ->type('golfhandicap', 'Geen')
+                ->maximize();
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
                 ->press('#aanmeldknop')
                 ->assertDontSee('Uw aanmelding is verzonden!');
 
@@ -123,7 +140,10 @@ class EnrollForEventTest extends DuskTestCase
                 ->type('phonenumber', '0612345678')
                 ->type('address', 'Teststraat 1')
                 ->type('city', 'Teststad')
-                ->type('disability', 'Geen')
+                ->type('golfhandicap', 'Geen')
+                ->maximize();
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
                 ->press('#aanmeldknop')
                 ->assertDontSee('Uw aanmelding is verzonden!');
 
@@ -136,7 +156,10 @@ class EnrollForEventTest extends DuskTestCase
                 ->type('phonenumber', '0612345678')
                 ->type('address', 'Teststraat 1')
                 ->type('city', 'Teststad')
-                ->type('disability', 'Geen')
+                ->type('golfhandicap', 'Geen')
+                ->maximize();
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
                 ->press('#aanmeldknop')
                 ->assertDontSee('Uw aanmelding is verzonden!');
         });
@@ -159,7 +182,10 @@ class EnrollForEventTest extends DuskTestCase
                 ->type('phonenumber', '456as4df54fd65a4sdf65saf')
                 ->type('address', 'Teststraat 1')
                 ->type('city', 'Teststad')
-                ->type('disability', 'Geen')
+                ->type('golfhandicap', 'Geen')
+                ->maximize();
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
                 ->press('#aanmeldknop')
                 ->assertDontSee('Uw aanmelding is verzonden!');
 
@@ -172,7 +198,10 @@ class EnrollForEventTest extends DuskTestCase
                 ->type('phonenumber', ';[]_=asdffda151256124-+()sdfsaf')
                 ->type('address', 'Teststraat 1')
                 ->type('city', 'Teststad')
-                ->type('disability', 'Geen')
+                ->type('golfhandicap', 'Geen')
+                ->maximize();
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
                 ->press('#aanmeldknop')
                 ->assertDontSee('Uw aanmelding is verzonden!');
 
@@ -185,7 +214,10 @@ class EnrollForEventTest extends DuskTestCase
                 ->type('phonenumber', '061234567')
                 ->type('address', 'Teststraat 1')
                 ->type('city', 'Teststad')
-                ->type('disability', 'Geen')
+                ->type('golfhandicap', 'Geen')
+                ->maximize();
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
                 ->press('#aanmeldknop')
                 ->assertDontSee('Uw aanmelding is verzonden!');
 
@@ -198,7 +230,10 @@ class EnrollForEventTest extends DuskTestCase
                 ->type('phonenumber', $string)
                 ->type('address', 'Teststraat 1')
                 ->type('city', 'Teststad')
-                ->type('disability', 'Geen')
+                ->type('golfhandicap', 'Geen')
+                ->maximize();
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
                 ->press('#aanmeldknop')
                 ->assertDontSee('Uw aanmelding is verzonden!');
         });
@@ -221,7 +256,10 @@ class EnrollForEventTest extends DuskTestCase
                 ->type('phonenumber', '0612345678')
                 ->type('address', '')
                 ->type('city', 'Teststad')
-                ->type('disability', 'Geen')
+                ->type('golfhandicap', 'Geen')
+                ->maximize();
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
                 ->press('#aanmeldknop')
                 ->assertDontSee('Uw aanmelding is verzonden!');
 
@@ -234,7 +272,10 @@ class EnrollForEventTest extends DuskTestCase
                 ->type('phonenumber', '0612345678')
                 ->type('address', $string)
                 ->type('city', 'Teststad')
-                ->type('disability', 'Geen')
+                ->type('golfhandicap', 'Geen')
+                ->maximize();
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
                 ->press('#aanmeldknop')
                 ->assertDontSee('Uw aanmelding is verzonden!');
         });
@@ -257,7 +298,10 @@ class EnrollForEventTest extends DuskTestCase
                 ->type('phonenumber', '0612345678')
                 ->type('address', 'Teststraat 6')
                 ->type('city', '')
-                ->type('disability', 'Geen')
+                ->type('golfhandicap', 'Geen')
+                ->maximize();
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
                 ->press('#aanmeldknop')
                 ->assertDontSee('Uw aanmelding is verzonden!');
 
@@ -270,13 +314,35 @@ class EnrollForEventTest extends DuskTestCase
                 ->type('phonenumber', '0612345678')
                 ->type('address', 'Teststraat 6')
                 ->type('city', $string)
-                ->type('disability', 'Geen')
+                ->type('golfhandicap', 'Geen')
+                ->maximize();
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
                 ->press('#aanmeldknop')
                 ->assertDontSee('Uw aanmelding is verzonden!');
         });
     }
 
-    public function testForm_BadDisability_shouldFail(): void
+    public function testForm_emptyGolfhandicap_shouldSucceed(): void
+    {
+        $this->browse(function (Browser $browser) {
+        $browser->visit('/events/enroll/' . (DB::table('events')->max('id')))
+            ->assertSee('Inschrijven voor Evenement')
+            ->type('name', 'Test')
+            ->type('birthday', '2000-01-01')
+            ->type('email', 'test@gmail.com')
+            ->type('phonenumber', '0612345678')
+            ->type('address', 'Teststraat 6')
+            ->type('city', 'Teststad')
+            ->type('golfhandicap', '')
+            ->maximize();
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
+            ->press('aanmeldknop')
+            ->assertSee('Uw aanmelding is verzonden!');
+        });
+    }
+    public function testForm_BadGolfhandicap_shouldFail(): void
     {
         $this->browse(function (Browser $browser) {
             $string = '';
@@ -284,21 +350,11 @@ class EnrollForEventTest extends DuskTestCase
                 $string .= 'a';
             }
 
-            //Test required field
-            $browser->visit('/events/enroll/'.(DB::table('events')->max('id')))
-                ->assertSee('Inschrijven voor Evenement')
-                ->type('name', 'Test')
-                ->type('birthday', '2000-01-01')
-                ->type('email', 'test@gmail.com')
-                ->type('phonenumber', '0612345678')
-                ->type('address', 'Teststraat 6')
-                ->type('city', 'Teststad')
-                ->type('disability', '')
-                ->press('#aanmeldknop')
-                ->assertDontSee('Uw aanmelding is verzonden!');
-
             //Test max length
             $browser->visit('/events/enroll/'.(DB::table('events')->max('id')))
+                ->maximize();
+            $browser->script('window.scrollTo(0, 1000);');
+            $browser
                 ->assertSee('Inschrijven voor Evenement')
                 ->type('name', 'Test')
                 ->type('birthday', '2000-01-01')
@@ -306,8 +362,8 @@ class EnrollForEventTest extends DuskTestCase
                 ->type('phonenumber', '0612345678')
                 ->type('address', 'Teststraat 6')
                 ->type('city', 'Teststad')
-                ->type('disability', $string)
-                ->press('#aanmeldknop')
+                ->type('golfhandicap', $string)
+                ->click('#aanmeldknop')
                 ->assertDontSee('Uw aanmelding is verzonden!');
         });
     }


### PR DESCRIPTION
# Pull request

- Geen epic

## Summary

### Description

- beperking veld in inschrijven voor evenement aangepast naar niet required en als naam spelershandicap

### User story 

- S8S-160 [1] Als websitebeheerder wil ik dat het beperking veld in het inschrijfformulier wordt gewijzigd, zodat de websitegebruikers een beperking niet negatief interpreteren

### List of acceptation criteria

- Het veld voor de beperking bij het inschrijfformulier voor een evenement moet gewijzigd worden naar Spelershandicap
- Het veld moet niet verplicht zijn

## Challenges and Solutions

### Challenge 1

- vinden waar de regel staat dat het veld verplicht is.

### Solution 1

- ctrl+f

## User Interface

![image](https://user-images.githubusercontent.com/103929586/231757215-737a7cfd-6d51-419f-b173-8bf8d3412888.png)

## Checklist

- [x] All tests are passed.
- [x] Code compiles.
- [x] No errors in other parts of the program.
- [x] Code is commented on difficult parts.
- [x] All commits are clearly named.
- [x] Two people are mentioned to review this pull request
- [x] There is a clear description of the functionality and images are added for clarification.
- [x] Hours are registered in Clockify.
- [x] Coding standards have been adhered to.
