### PR TITLE
Rooster crud

### DIFF
--- a/app/Models/TrainingSession.php
+++ b/app/Models/TrainingSession.php
@@ -9,6 +9,7 @@ class TrainingSession extends Model
 {
     protected $table = 'training_session';
     protected $primaryKey = 'Id';
+    public $timestamps = false;
     protected $fillable = [
         'Id',
         'GroupNumber',

--- a/resources/lang/nl/validation.php
+++ b/resources/lang/nl/validation.php
@@ -173,7 +173,10 @@ return [
         'time' => 'tijd',
         'name' => 'naam',
         'image' => 'afbeelding',
-        'phonenumber' => 'telefoonnummer'
+        'phonenumber' => 'telefoonnummer',
+        'starttime' => 'begintijd',
+        'endtime' => 'eindtijd',
+        'group' => 'groep'
     ],
 
     'values' => [

--- a/resources/lang/nl/validation.php
+++ b/resources/lang/nl/validation.php
@@ -16,7 +16,7 @@ return [
     'accepted'             => ':Attribute dient te worden geaccepteerd.',
     'accepted_if'          => ':Attribute dient te worden geaccepteerd wanneer :other :value is.',
     'active_url'           => ':Attribute is geen geldige URL.',
-    'after'                => ':Attribute moet een datum zijn na :date.',
+    'after'                => ':Attribute moet na :date zijn.',
     'after_or_equal'       => ':Attribute moet een datum zijn na of gelijk aan :date.',
     'alpha'                => ':Attribute mag alleen letters bevatten.',
     'alpha_dash'           => ':Attribute mag alleen letters, nummers, en strepen bevatten.',

--- a/resources/views/layouts/layout.blade.php
+++ b/resources/views/layouts/layout.blade.php
@@ -171,7 +171,7 @@
                 <a class="nav-link text-dark {{ (request()->segment(1) == 'index') ? 'font-weight-bold' : '' }}" href="/">Startpagina</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link text-dark {{ (request()->segment(1) == 'training') ? 'font-weight-bold' : '' }}" href="/training">Trainingen</a>
+                <a class="nav-link text-dark {{ (request()->segment(1) == 'training') ? 'font-weight-bold' : '' }}" href="/trainingsessions">Trainingen</a>
             </li>
             <li class="nav-item">
                 <a class="nav-link text-dark {{ (request()->segment(1) == 'evenement') ? 'font-weight-bold' : '' }}" href="/events">Evenementen</a>

--- a/resources/views/training/create.blade.php
+++ b/resources/views/training/create.blade.php
@@ -1,0 +1,61 @@
+@extends('layouts.layout')
+ 
+@section('content')
+<div class="row">
+    <div class="col-sm-8 offset-sm-2">
+        <h1 class="display-3">Voeg training toe</h1>
+        <a href="/trainingsessions" class="btn btn-primary">Ga terug</a>
+        <div>
+            @if ($errors->any())
+            <div class="alert alert-danger">
+                <ul>
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div><br>
+            @endif
+            <br>
+            <form method="post" action="{{ route('trainingsessions.store') }}">
+                @csrf
+                <div class="form-group">
+                    <label for="date">Datum:</label>
+                    <input type="date" class="form-control" name="date" id="date"/>
+                </div><br>
+        
+                <div class="form-group">
+                    <label for="starttime">Begintijd:</label>
+                    <input type="time" class="form-control" name="starttime" id="starttime"/>
+                </div><br>
+                
+                <div class="form-group">
+                    <label for="endtime">Eindtijd:</label>
+                    <input type="time" class="form-control" name="endtime" id="endtime"/>
+                </div><br>
+        
+                <div class="form-group">
+                    <label for="body">Beschrijving:</label>
+                    <textarea rows="5" class="form-control" name="body" id="body"></textarea>
+                </div><br>
+                
+                <label class="form-check-label">Trainingsgroep:</label>
+                @foreach($groups as $group)
+                <div class="form-check">
+                    <input type="radio" class="form-check-input" value="{{$group->GroupNumber}}" name="group" id="{{$group->Name}}"/>
+                    <label for="{{$group->Name}}" class="form-check-label">{{$group->Name}}</label>
+                </div>
+                @endforeach
+                <br>
+                
+                <label class="form-check-label" for="vacationweek">Vakantieweek:</label>
+                <div class="form-check">
+                    <input type="checkbox" class="form-check-input" name="vacationweek" id="vacationweek" value="true"/>
+                    <label for="vacationweek">Ja</label>
+                </div><br>
+                
+                <button type="submit" class="btn btn-primary">Voeg training toe</button>
+            </form>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/training/edit.blade.php
+++ b/resources/views/training/edit.blade.php
@@ -1,0 +1,61 @@
+@extends('layouts.layout') 
+@section('content')
+<div class="row">
+    <div class="col-sm-8 offset-sm-2">
+        <h1 class="display-3">Evenement aanpassen
+        <a href="/trainingsessions" class="btn btn-primary">Ga terug</a></h1>
+ 
+        @if ($errors->any())
+            <div class="alert alert-danger">
+                <ul>
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+            <br /> 
+        @endif
+        <form method="post" action="{{ route('trainingsessions.update', $session->Id) }}">
+            @method('PATCH') 
+            @csrf
+
+            <div class="form-group">
+                <label for="date">Datum:</label>
+                <input type="date" class="form-control" name="date" id="date" value="{{$session->Date}}"/>
+            </div><br>
+            
+            <div class="form-group">
+                <label for="starttime">Begintijd:</label>
+                <input type="time" class="form-control" name="starttime" value="{{ $session->StartTime }}" id="time"/>
+            </div><br>
+            
+            <div class="form-group">
+                <label for="endtime">Eindtijd:</label>
+                <input type="time" class="form-control" name="endtime" value="{{ $session->EndTime }}" id="time"/>
+            </div><br>
+
+            <div class="form-group">
+                <label for="body">Beschrijving:</label>
+                <textarea rows="5" class="form-control" name="body" id="body">{{ $session->Description }}</textarea>
+            </div><br>
+                
+            <label class="form-check-label">Trainingsgroep:</label>
+            @foreach($groups as $group)
+            <div class="form-check">
+                <input type="radio" class="form-check-input" value="{{$group->GroupNumber}}" name="group" id="{{$group->Name}}" {{$session->GroupNumber == $group->GroupNumber ? 'checked' : ''}}/>
+                <label for="{{$group->Name}}" class="form-check-label">{{$group->Name}}</label>
+            </div>
+            @endforeach
+            <br>
+            
+            <label class="form-check-label" for="vacationweek">Vakantieweek:</label>
+            <div class="form-check">
+                <input type="checkbox" class="form-check-input" name="vacationweek" value="true" {{$session->IstrainingSession == 0 ? 'checked' : ''}}/>
+                <label for="vacationweek">Ja</label>
+            </div><br>
+
+            <button type="submit" class="btn btn-primary">Update</button>
+        </form>
+    </div>
+</div>
+@endsection

--- a/resources/views/training/index.blade.php
+++ b/resources/views/training/index.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 <div class="row">
     <div class="col-sm-12 container">
-        <h1 class="display-3">Trainings</h1>
+        <h1 class="display-3">Trainingen</h1>
         <div class="justify-content-between d-lg-flex mb-3">
             <a href="{{ route('trainingsessions.create')}}" class="btn btn-primary">Creeër nieuwe training</a>
             <a class="btn btn-secondary" href="/training">Terug</a>
@@ -11,6 +11,11 @@
         @if(session()->get('success'))
             <div class="alert alert-success">
                 {{ session()->get('success') }}
+            </div>
+        @endif
+        @if(session()->get('error'))
+            <div class="alert alert-danger">
+                {{ session()->get('error') }}
             </div>
         @endif
         <table class="table table-striped">
@@ -35,9 +40,7 @@
                         <td>{{$session->EndTime}}</td>
                         <td>{{$session->Description}}</td>
                         <td>Groep {{$session->GroupNumber}}</td>
-                        <td>
-                            <input type="checkbox" class="form-check-input" {{$session->IstrainingSession == 1 ? '' : 'checked'}} disabled/>
-                        </td>
+                        <td>{{$session->IstrainingSession == 1 ? 'X' : '✓'}}</td>
                         <td>
                             <a href="{{ route('trainingsessions.edit',$session->Id)}}" class="btn btn-primary">Aanpassen</a>
                         </td>

--- a/resources/views/training/index.blade.php
+++ b/resources/views/training/index.blade.php
@@ -6,7 +6,6 @@
         <h1 class="display-3">Trainingen</h1>
         <div class="justify-content-between d-lg-flex mb-3">
             <a href="{{ route('trainingsessions.create')}}" class="btn btn-primary">Creeër nieuwe training</a>
-            <a class="btn btn-secondary" href="/training">Terug</a>
         </div>
         @if(session()->get('success'))
             <div class="alert alert-success">

--- a/resources/views/training/index.blade.php
+++ b/resources/views/training/index.blade.php
@@ -1,0 +1,57 @@
+@extends('layouts.layout')
+
+@section('content')
+<div class="row">
+    <div class="col-sm-12 container">
+        <h1 class="display-3">Trainings</h1>
+        <div class="justify-content-between d-lg-flex mb-3">
+            <a href="{{ route('trainingsessions.create')}}" class="btn btn-primary">Creeër nieuwe training</a>
+            <a class="btn btn-secondary" href="/training">Terug</a>
+        </div>
+        @if(session()->get('success'))
+            <div class="alert alert-success">
+                {{ session()->get('success') }}
+            </div>
+        @endif
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <td>ID</td>
+                    <td>Datum</td>
+                    <td>Begintijd</td>
+                    <td>Eindtijd</td>
+                    <td>Beschrijving</td>
+                    <td>Groep</td>
+                    <td>Vakantieweek</td>
+                    <td colspan = 2>Actions</td>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($sessions as $session)
+                    <tr>
+                        <td>{{$session->Id}}</td>
+                        <td>{{$session->Date}} </td>
+                        <td>{{$session->StartTime}}</td>
+                        <td>{{$session->EndTime}}</td>
+                        <td>{{$session->Description}}</td>
+                        <td>Groep {{$session->GroupNumber}}</td>
+                        <td>
+                            <input type="checkbox" class="form-check-input" {{$session->IstrainingSession == 1 ? '' : 'checked'}} disabled/>
+                        </td>
+                        <td>
+                            <a href="{{ route('trainingsessions.edit',$session->Id)}}" class="btn btn-primary">Aanpassen</a>
+                        </td>
+                        <td>
+                            <form action="{{ route('trainingsessions.destroy', $session->Id)}}" method="post">
+                            @csrf
+                            @method('DELETE')
+                            <button class="btn btn-danger" type="submit">Verwijderen</button>
+                            </form>
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    <div>
+</div>
+@endsection

--- a/resources/views/training/training.blade.php
+++ b/resources/views/training/training.blade.php
@@ -3,7 +3,6 @@
 @section('content')
 <div class="container">
     <h1>Trainingen</h1>
-    <a class="btn btn-secondary" href="/trainingsessions">Trainingen onderhouden</a>
     @foreach($trainingGroups as $group)
 
         <h2>Traininggroep {{$group->GroupNumber}}</h2>

--- a/resources/views/training/training.blade.php
+++ b/resources/views/training/training.blade.php
@@ -3,6 +3,7 @@
 @section('content')
 <div class="container">
     <h1>Trainingen</h1>
+    <a class="btn btn-secondary" href="/trainingsessions">Trainingen onderhouden</a>
     @foreach($trainingGroups as $group)
 
         <h2>Traininggroep {{$group->GroupNumber}}</h2>

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,11 +46,11 @@ Route::get('slider-delete/{slider}', [SliderController::class, 'delete'])->name(
 
 //Resource routes
 Route::resource('slider', SliderController::class);
-Route::resource('training', TrainingController::class);
 
 //Training routes
 
-//Route::resource('trainingsessions', TrainingController::class);
+Route::resource('trainingsessions', TrainingController::class);
+Route::get('training', [TrainingController::class, 'training']);
 Route::get('/training/signout', [TrainingController::class, 'signout']);
 Route::post('/training/signout', [TrainingController::class, 'sendsignoutmail']);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -81,7 +81,11 @@ Route::middleware(['role:admin'])->group(function () {
     //Event routes
     Route::resource('events', EventController::class);
 
+    //Team routes
     Route::resource('members', TeamController::class);
+
+    //Training routes
+    Route::resource('trainingsessions', TrainingController::class);
 
     //TODO: voor een andere user story
     Route::get('/galerij/aanmakenAlbum', [GalleryController::class, 'create']);

--- a/tests/Browser/TrainingTest.php
+++ b/tests/Browser/TrainingTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Browser;
+
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+use Illuminate\Foundation\Testing\DatabaseTruncation;
+
+class TrainingTest extends DuskTestCase
+{
+    use DatabaseTruncation;
+    /**
+     * A Dusk test example.
+     */
+    public function testCreateTraining(): void
+    {
+        $this->artisan('db:seed');
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/trainingsessions')
+                    ->clickLink("Creeër nieuwe training")
+                    ->type('date', '12122023')
+                    ->type('starttime', '1200P')
+                    ->type('endtime', '1300')
+                    ->type('body', 'dusktest')
+                    ->radio('group', '2')
+                    ->check('vacationweek')
+                    ->press('Voeg training toe')
+                    ->assertPathIs('/trainingsessions')
+                    ->assertSee('Trainingsessie opgeslagen.');
+        });
+    }
+
+    public function testFailCreateTraining(): void
+    {
+        $this->artisan('db:seed');
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/trainingsessions')
+                    ->clickLink('Creeër nieuwe training')
+                    ->press('Voeg training toe')
+                    ->assertPathIs('/trainingsessions/create')
+                    ->assertSee('Het datum veld is verplicht.')
+                    ->assertSee('Het begintijd veld is verplicht.')
+                    ->assertSee('Het eindtijd veld is verplicht.')
+                    ->assertSee('Het beschrijving veld is verplicht.')
+                    ->assertSee('Het groep veld is verplicht.');
+        });
+    }
+
+    public function testEditTraining(): void
+    {
+        $this->artisan('db:seed');
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/trainingsessions')
+                    ->clickLink('Aanpassen')
+                    ->type('date', '12122023')
+                    ->type('starttime', '1200P')
+                    ->type('endtime', '1300')
+                    ->type('body', 'dusktest')
+                    ->radio('group', '2')
+                    ->check('vacationweek')
+                    ->press('Update')
+                    ->assertPathIs('/trainingsessions')
+                    ->assertSee('Trainingsessie opgeslagen.');
+        });
+    }
+
+    public function testFailEditTraining(): void
+    {
+        $this->artisan('db:seed');
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/trainingsessions')
+                    ->clickLink('Aanpassen')
+                    ->type('date', '')
+                    ->type('starttime', '')
+                    ->type('endtime', '')
+                    ->type('body', '')
+                    ->press('Update')
+                    ->assertPathIs('/trainingsessions/*/edit')
+                    ->assertSee('Het datum veld is verplicht.')
+                    ->assertSee('Het begintijd veld is verplicht.')
+                    ->assertSee('Het eindtijd veld is verplicht.')
+                    ->assertSee('Het beschrijving veld is verplicht.');
+        });
+    }
+
+    public function testDeleteTraining(): void
+    {
+        $this->artisan('db:seed');
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/trainingsessions')
+                    ->press("Verwijderen")
+                    ->assertPathIs("/trainingsessions")
+                    ->assertSee("Trainingsessie verwijderd.");
+        });
+    }
+}


### PR DESCRIPTION
# Pull request

- Oefensessies

## Summary

### Description

- CRUD functionality for the training sessions

### User story 

- Als websitebeheerder wil ik het rooster kunnen beheren, zodat de andere begeleiders/coaches en deelnemers op de hoogte zijn van de aangebrachte wijzigingen aan het rooster.

### List of acceptation criteria

- Het rooster kan gedeeld worden.

- Het rooster heeft CRUD eigenschappen
- Er kan een nieuw rooster toe worden gevoegd.
- Het rooster kan gewijzigd worden.
- Het rooster kan worden ingezien

- Er is zichtbaar wanneer de vakanties plaatsvinden.

## Challenges and Solutions

### Challenge 1

- Testing

### Solution 1

- Copied stuff from different testing files

## User Interface

- ![image](https://user-images.githubusercontent.com/46578728/232205657-bedc9993-0765-451d-b3e3-321224c47da1.png)
Index page
- ![image](https://user-images.githubusercontent.com/46578728/232205587-3ecf81b5-08ad-4ebb-bbf9-1ce1bfa07b10.png)
Create page
- ![image](https://user-images.githubusercontent.com/46578728/232205616-bfb025e7-1016-468b-b79a-485be79f34de.png)
Edit page



## Checklist

- [x] All tests are passed.
- [x] Code compiles.
- [x] No errors in other parts of the program.
- [x] Code is commented on difficult parts.
- [x] All commits are clearly named.
- [x] Two people are mentioned to review this pull request
- [x] There is a clear description of the functionality and images are added for clarification.
- [x] Hours are registered in Clockify.
- [x] Coding standards have been adhered to.
