### PR TITLE
Feature/event price

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -118,6 +118,7 @@ class EventController extends Controller
         $event->date = $request->get('date');
         $event->time = $request->get('time');
         $event->price = $request->get('price');
+        $event->bankaccount = $request->get('bankaccount');
         $event->body = $request->get('body');
         $event->updated_at = $request->get('updated_at');
         $event->groups()->detach();

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -67,7 +67,6 @@ class EventController extends Controller
      */
     public function show(string $id)
     {
-
         try {
             $event = Event::findOrFail($id);
             $first_group = $event->groups->first();
@@ -76,9 +75,6 @@ class EventController extends Controller
         } catch (\Exception $e) {
             return redirect('/evenement')->with('error', 'Evenement niet gevonden.');
         }
-
-
-
     }
 
     public function enroll(int $id)
@@ -121,6 +117,7 @@ class EventController extends Controller
         $event->title = $request->get('title');
         $event->date = $request->get('date');
         $event->time = $request->get('time');
+        $event->price = $request->get('price');
         $event->body = $request->get('body');
         $event->updated_at = $request->get('updated_at');
         $event->groups()->detach();

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79ea6764e4d3af4217f234a80fe1dba5",
+    "content-hash": "dac516c36de01129f96212bb1af613b0",
     "packages": [
         {
             "name": "brick/math",
@@ -5640,16 +5640,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "3.6.1",
+            "version": "3.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "57815c7bbcda3cd18871d253c1dd8cbe56f8526e"
+                "reference": "b4bd1cfbd2b916951696d82e57d054394d84864c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/57815c7bbcda3cd18871d253c1dd8cbe56f8526e",
-                "reference": "57815c7bbcda3cd18871d253c1dd8cbe56f8526e",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/b4bd1cfbd2b916951696d82e57d054394d84864c",
+                "reference": "b4bd1cfbd2b916951696d82e57d054394d84864c",
                 "shasum": ""
             },
             "require": {
@@ -5665,9 +5665,9 @@
                 "doctrine/coding-standard": "11.1.0",
                 "fig/log-test": "^1",
                 "jetbrains/phpstorm-stubs": "2022.3",
-                "phpstan/phpstan": "1.10.3",
+                "phpstan/phpstan": "1.10.9",
                 "phpstan/phpstan-strict-rules": "^1.5",
-                "phpunit/phpunit": "9.6.4",
+                "phpunit/phpunit": "9.6.6",
                 "psalm/plugin-phpunit": "0.18.4",
                 "squizlabs/php_codesniffer": "3.7.2",
                 "symfony/cache": "^5.4|^6.0",
@@ -5732,7 +5732,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/3.6.1"
+                "source": "https://github.com/doctrine/dbal/tree/3.6.2"
             },
             "funding": [
                 {
@@ -5748,7 +5748,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-02T19:26:24+00:00"
+            "time": "2023-04-14T07:25:38+00:00"
         },
         {
             "name": "doctrine/deprecations",

--- a/database/migrations/2023_03_07_103540_create-events-table.php
+++ b/database/migrations/2023_03_07_103540_create-events-table.php
@@ -15,6 +15,7 @@ return new class extends Migration
             $table->id();
             $table->string('title');
             $table->date('date');
+            $table->double('price')->nullable();
             $table->time('time')->nullable();
             $table->string('slug')->unique()->nullable();
             $table->text('body');

--- a/database/migrations/2023_03_07_103540_create-events-table.php
+++ b/database/migrations/2023_03_07_103540_create-events-table.php
@@ -16,6 +16,7 @@ return new class extends Migration
             $table->string('title');
             $table->date('date');
             $table->double('price')->nullable();
+            $table->string('bankaccount')->nullable();
             $table->time('time')->nullable();
             $table->string('slug')->unique()->nullable();
             $table->text('body');

--- a/database/seeders/EventAndGroupSeeder.php
+++ b/database/seeders/EventAndGroupSeeder.php
@@ -33,6 +33,7 @@ class EventAndGroupSeeder extends Seeder
         $prise = Event::create([
             'title' => 'Special Golf - Prise d\'Eau',
             'date' => '2023-04-08',
+            'price' => 12,
             'time' => '12:00:00',
             'slug' => 'event_3',
             'body' => 'Special Golf organiseert op deze dag een ontmoet met G-Golf Prise d\'Eau op de banen van BurgGolf Haverleij. Deelnemers en begeleiders (unified) spelen een ronde op de Par-3 baan en gaan aan de slag met skills. Deze ontmoeting is het tegenbezoek voor het spelen op Prise d’Eau in mei 2022. Na ontvangst in het clubgebouw van BurgGolf Haverleij waar de flights bekend worden gemaakt wordt er gestart op de  Par-3 baan. We sluiten af met een lunch in het clubgebouw.'
@@ -42,6 +43,7 @@ class EventAndGroupSeeder extends Seeder
             'title' => 'Super-G \'s-Hertogenbosch',
             'date' => '2023-06-04',
             'time' => '12:00:00',
+            'price'=> 12.50,
             'slug' => 'event_4',
             'body' => 'In navolging van 2022 gaat Super-G weer plaatsvinden. Aan dit evenement nemen deel veel verenigingen en stichtingen o.a. tennis, paardrijden, basketbal, voetbal, wielrennen, wandelen, judo, hockey, darten en petanque uit de gemeente ’s-Hertogenbosch.
             Ook Special Golf (G-Golf) is op deze dag gastheer op BurgGolf Haverleij, waar mensen met een verstandelijke beperking kunnen kennismaken met het Golfen. Een parcours bestaande uit golfvaardigheid skills kan door de deelnemers worden afgelegd, waarbij begeleiders van Special Golf hun de eerste beginselen zullen aanreiken. Deze dag staat dan ook in het teken van verbinden waar we iedereen een leuke ervaring willen meegeven. Voor het programma op 4 juni 2023 komen wij tijdig met nadere  informatie over de locatie en tijden, bezoek daarvoor de website: www.super-g.nl  of www.specialgolfhaverleij2021.com.'

--- a/database/seeders/EventAndGroupSeeder.php
+++ b/database/seeders/EventAndGroupSeeder.php
@@ -17,6 +17,7 @@ class EventAndGroupSeeder extends Seeder
         $indoorGolf = Event::create([
             'title' => 'Indoor-Golf-Middag',
             'date' => '2023-01-21',
+            'price' => 15,
             'time' => '12:00:00',
             'slug' => 'event_1',
             'bankaccount' => 'NL41 RABO 1234 5678 90',

--- a/database/seeders/EventAndGroupSeeder.php
+++ b/database/seeders/EventAndGroupSeeder.php
@@ -19,6 +19,7 @@ class EventAndGroupSeeder extends Seeder
             'date' => '2023-01-21',
             'time' => '12:00:00',
             'slug' => 'event_1',
+            'bankaccount' => 'NL41 RABO 1234 5678 90',
             'body' => 'Tijdens de winterstop organiseert Special Golf een Indoor-Golf-Middag voor de deelnemers van Special Golf. Begeleiders gaan bij Cello op De Binckhorst in Rosmalen een put & chip parcours uitzetten waar de deelnemers hun golfvaardigheid kunnen oefenen op verschillende onderdelen. We sluiten de middag af met een drankje.'
         ]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
     "packages": {
         "": {
             "dependencies": {
-                "bootstrap": "^5.2.3"
+                "bootstrap": "^5.2.3",
+                "bootstrap-icons": "^1.10.4"
             },
             "devDependencies": {
                 "@tailwindcss/forms": "^0.5.2",
@@ -558,6 +559,11 @@
             "peerDependencies": {
                 "@popperjs/core": "^2.11.6"
             }
+        },
+        "node_modules/bootstrap-icons": {
+            "version": "1.10.4",
+            "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.10.4.tgz",
+            "integrity": "sha512-eI3HyIUmpGKRiRv15FCZccV+2sreGE2NnmH8mtxV/nPOzQVu0sPEj8HhF1MwjJ31IhjF0rgMvtYOX5VqIzcb/A=="
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -2035,6 +2041,11 @@
             "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.3.tgz",
             "integrity": "sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==",
             "requires": {}
+        },
+        "bootstrap-icons": {
+            "version": "1.10.4",
+            "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.10.4.tgz",
+            "integrity": "sha512-eI3HyIUmpGKRiRv15FCZccV+2sreGE2NnmH8mtxV/nPOzQVu0sPEj8HhF1MwjJ31IhjF0rgMvtYOX5VqIzcb/A=="
         },
         "brace-expansion": {
             "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "vite": "^4.0.0"
     },
     "dependencies": {
-        "bootstrap": "^5.2.3"
+        "bootstrap": "^5.2.3",
+        "bootstrap-icons": "^1.10.4"
     }
 }

--- a/resources/views/detailEvenement.blade.php
+++ b/resources/views/detailEvenement.blade.php
@@ -29,6 +29,9 @@
                 <span>
                     €{{number_format($event->price, 2, ',', ' ')}}
                  </span>
+                 <span>
+                    {{$event->bankaccount}}
+                 </span>
                 @endif
                 <span>
                     <i class="bi bi-geo fs-2x"></i>
@@ -64,7 +67,7 @@
                                 Prijs: €{{number_format($event->price, 2, ',', ' ')}}
                             </p>
                             <p>
-                                Gelieve dit bedrag over te maken naar: NL 38 RABO 0118102206 als wilt deelnemen aan dit evenement
+                                Gelieve dit bedrag over te maken naar: {{$event->bankaccount}} als wilt deelnemen aan dit evenement
                             </p>
                         </div>
                     @endif

--- a/resources/views/detailEvenement.blade.php
+++ b/resources/views/detailEvenement.blade.php
@@ -17,24 +17,29 @@
             </div>
 
             <div class="justify-content-between mb-3 mt-3">
-            <span>
-                <i class="bi bi-calendar-check"></i>
-                {{$event->date}}
-            </span>
                 <span>
-                <i class="bi bi-clock fs-2x"></i>
-                {{date('H:i', strtotime($event->time))}}
-             </span>
+                    <i class="bi bi-calendar-check"></i>
+                    {{$event->date}}
+                </span>
                 <span>
-            <i class="bi bi-geo fs-2x"></i>
-            {{$first_group->street}} {{$first_group->housenumber}}, {{$first_group->city}}
-        </span>
+                    <i class="bi bi-calendar-check"></i>
+                    {{$event->date}}
+                </span>
+                @if($event->price > 0)
+                <span>
+                    €{{number_format($event->price, 2, ',', ' ')}}
+                 </span>
+                @endif
+                <span>
+                    <i class="bi bi-geo fs-2x"></i>
+                    {{$first_group->street}} {{$first_group->housenumber}}, {{$first_group->city}}
+                </span>
                 <a class="text-decoration-none" rel="Link naar de website van de golfclub"
                    href="https://{{$first_group->link}}">
-            <span>
-                <i class="bi bi-link fs-2x"></i>
-            {{$first_group->link}}
-            </span>
+                    <span>
+                        <i class="bi bi-link fs-2x"></i>
+                        {{$first_group->link}}
+                    </span>
                 </a>
             </div>
             <div id="detailsImages" class=" d-lg-flex">
@@ -53,6 +58,16 @@
                     <div class="mb-4">
                         {{$event->body}}
                     </div>
+                    @if($event->price > 0)
+                        <div>
+                            <p>
+                                Prijs: €{{number_format($event->price, 2, ',', ' ')}}
+                            </p>
+                            <p>
+                                Gelieve dit bedrag over te maken naar: NL 38 RABO 0118102206 als wilt deelnemen aan dit evenement
+                            </p>
+                        </div>
+                    @endif
                 </div>
                 <div class="col-sm-4">
                     <div id="cardEvent" class="card border-0">
@@ -61,19 +76,25 @@
                         </div>
                         <div class="card-body text-left">
                             <div>
-                        <span>
-                             <i class="bi bi-calendar-check fs-2x"></i>
-                                {{$event->date}}
-                        </span>
+                                <span>
+                                     <i class="bi bi-calendar-check fs-2x"></i>
+                                        {{$event->date}}
+                                </span>
                             </div>
 
                             <div>
-                        <span>
-                        <i class="bi bi-clock fs-2x"></i>
-                            {{date('H:i', strtotime($event->time))}}
-
-                        </span>
+                                <span>
+                                <i class="bi bi-clock fs-2x"></i>
+                                    {{date('H:i', strtotime($event->time))}}
+                                </span>
                             </div>
+                            @if($event->price > 0)
+                            <div>
+                                <span>
+                                    €{{number_format($event->price, 2, ',', ' ')}}
+                                </span>
+                            </div>
+                            @endif
                             <div>
                         <span>
                         <i class="bi bi-geo fs-2x"></i>
@@ -81,12 +102,13 @@
                         </span>
                             </div>
                             <div>
-                                <a dusk="WebsiteLink" class="text-decoration-none " href="https://{{$first_group->link}}"
+                                <a dusk="WebsiteLink" class="text-decoration-none "
+                                   href="https://{{$first_group->link}}"
                                    rel="link naar de website van de golfclub">
-                         <span>
-                             <i class="bi bi-link fs-2x"></i>
-                        {{$first_group->link}}
-                        </span>
+                                     <span>
+                                         <i class="bi bi-link fs-2x"></i>
+                                        {{$first_group->link}}
+                                    </span>
                                 </a>
                             </div>
                         </div>

--- a/resources/views/detailEvenement.blade.php
+++ b/resources/views/detailEvenement.blade.php
@@ -27,6 +27,7 @@
                 </span>
                 @if($event->price > 0)
                 <span>
+                    <i class="bi bi-wallet"></i>
                     €{{number_format($event->price, 2, ',', ' ')}}
                  </span>
                  <span>
@@ -63,11 +64,14 @@
                     </div>
                     @if($event->price > 0)
                         <div>
-                            <p>
+                            <label>
                                 Prijs: €{{number_format($event->price, 2, ',', ' ')}}
+                            </label>
+                            <p>
+                                Rekeningnummer: {{$event->bankaccount}}
                             </p>
                             <p>
-                                Gelieve dit bedrag over te maken naar: {{$event->bankaccount}} als wilt deelnemen aan dit evenement
+                                Gelieve dit bedrag over te maken als u wenst deel te nemen aan dit evenement
                             </p>
                         </div>
                     @endif
@@ -94,7 +98,13 @@
                             @if($event->price > 0)
                             <div>
                                 <span>
+                                    <i class="bi bi-wallet"></i>
                                     €{{number_format($event->price, 2, ',', ' ')}}
+                                </span>
+                                <br />
+                                <span>
+                                    <i class="bi bi-dot"></i>
+                                    {{$event->bankaccount}}
                                 </span>
                             </div>
                             @endif

--- a/resources/views/events/create.blade.php
+++ b/resources/views/events/create.blade.php
@@ -1,5 +1,5 @@
 @extends('layouts.layout')
- 
+
 @section('content')
 <div class="row">
     <div class="col-sm-8 offset-sm-2">
@@ -17,26 +17,31 @@
             @endif
             <form method="post" action="{{ route('events.store') }}">
                 @csrf
-                <div class="form-group">    
+                <div class="form-group">
                     <label for="title">Titel:</label>
                     <input type="text" class="form-control" name="title" id="title"/>
                 </div>
-        
+
                 <div class="form-group">
                     <label for="date">Datum:</label>
                     <input type="date" class="form-control" name="date" id="date"/>
                 </div>
-        
+
                 <div class="form-group">
                     <label for="time">Tijd:</label>
                     <input type="time" class="form-control" name="time" id="time"/>
                 </div>
-        
+
+                <div class="form-group">
+                    <label for="price">Prijs:</label>
+                    <input type="number" class="form-control" name="price" id="price"/>
+                </div>
+
                 <div class="form-group">
                     <label for="body">Beschrijving:</label>
                     <textarea rows="5" class="form-control" name="body" id="body"></textarea>
                 </div>
-                
+
                 <label>Groepen:</label>
                 @foreach($groups as $group)
                 <div class="form-check">
@@ -44,7 +49,7 @@
                     <label for="{{$group->id}}" class="form-check-label">{{$group->name}}</label>
                 </div>
                 @endforeach
-                
+
                 <button type="submit" class="btn btn-primary">Voeg evenement toe</button>
             </form>
         </div>

--- a/resources/views/events/create.blade.php
+++ b/resources/views/events/create.blade.php
@@ -38,6 +38,11 @@
                 </div>
 
                 <div class="form-group">
+                    <label for="bankaccount">Rekeningnummer:</label>
+                    <input type="text" class="form-control" name="bankaccount" id="bankaccount"/>
+                </div>
+
+                <div class="form-group">
                     <label for="body">Beschrijving:</label>
                     <textarea rows="5" class="form-control" name="body" id="body"></textarea>
                 </div>

--- a/resources/views/events/edit.blade.php
+++ b/resources/views/events/edit.blade.php
@@ -40,6 +40,11 @@
             </div>
 
             <div class="form-group">
+                    <label for="bankaccount">Rekeningnummer:</label>
+                    <input type="text" class="form-control" name="bankaccount" value="{{ $event->bankaccount }}" id="bankaccount"/>
+                </div>
+
+            <div class="form-group">
                 <label for="body">Beschrijving:</label>
                 <textarea rows="5" class="form-control" name="body" id="body">{{ $event->body }}</textarea>
             </div>

--- a/resources/views/events/edit.blade.php
+++ b/resources/views/events/edit.blade.php
@@ -1,10 +1,10 @@
-@extends('layouts.layout') 
+@extends('layouts.layout')
 @section('content')
 <div class="row">
     <div class="col-sm-8 offset-sm-2">
         <h1 class="display-3">Evenement aanpassen
         <a href="/events" class="btn btn-primary">Ga terug</a></h1>
- 
+
         @if ($errors->any())
             <div class="alert alert-danger">
                 <ul>
@@ -13,36 +13,41 @@
                     @endforeach
                 </ul>
             </div>
-            <br /> 
+            <br />
         @endif
         <form method="post" action="{{ route('events.update', $event->id) }}">
-            @method('PATCH') 
+            @method('PATCH')
             @csrf
             <div class="form-group">
- 
+
                 <label for="title">Titel:</label>
                 <input type="text" class="form-control" name="title" value="{{ $event->title }}" id="title"/>
             </div>
- 
+
             <div class="form-group">
                 <label for="date">Datum:</label>
                 <input type="date" class="form-control" name="date" value="{{ $event->date }}" id="date"/>
             </div>
-            
+
             <div class="form-group">
                 <label for="time">Tijd:</label>
                 <input type="time" class="form-control" name="time" value="{{ $event->time }}" id="time"/>
             </div>
 
             <div class="form-group">
+                <label for="price">Prijs:</label>
+                <input type="number" min="0" step="0.01" lang="nl" class="form-control" name="price" value="{{ $event->price }}" id="price"/>
+            </div>
+
+            <div class="form-group">
                 <label for="body">Beschrijving:</label>
                 <textarea rows="5" class="form-control" name="body" id="body">{{ $event->body }}</textarea>
             </div>
- 
+
             <label>Groepen:</label>
                 @foreach($groups as $group)
                 <div class="form-check">
-                    <input type="checkbox" class="form-check-input" name="groups[]" value="{{$group->id}}" id="{{$group->id}}" 
+                    <input type="checkbox" class="form-check-input" name="groups[]" value="{{$group->id}}" id="{{$group->id}}"
                         {{in_array($group->id, $event->groups()->allRelatedIds()->toArray())? 'checked':''}}
                     />
                     <label for="{{$group->id}}" class="form-check-label">{{$group->name}}</label>

--- a/resources/views/events/evenement.blade.php
+++ b/resources/views/events/evenement.blade.php
@@ -37,6 +37,9 @@
                     <p>Prijs: €{{number_format($post->price, 2, ',', '')}}<br>
                         Zie meer informatie voor hoe je kunt betalen.</p>
                 @endif
+                @if($post->bankaccount != null)
+                    <p> Rekeningnummer: {{$post->bankaccount}}
+                @endif
                 <div class="d-flex justify-content-between">
                     <p class="col-sm-8">
                     {!!$post->body!!}

--- a/resources/views/events/evenement.blade.php
+++ b/resources/views/events/evenement.blade.php
@@ -31,6 +31,12 @@
 
             <div>
                 <p>Datum: {{$post->date}} om {{$post->time}}</p>
+                @if($post->price <= 0)
+                    <p>Prijs: Gratis</p>
+                @else
+                    <p>Prijs: €{{number_format($post->price, 2, ',', '')}}<br>
+                        Zie meer informatie voor hoe je kunt betalen.</p>
+                @endif
                 <div class="d-flex justify-content-between">
                     <p class="col-sm-8">
                     {!!$post->body!!}

--- a/resources/views/events/evenement.blade.php
+++ b/resources/views/events/evenement.blade.php
@@ -30,16 +30,14 @@
 
 
             <div>
-                <p>Datum: {{$post->date}} om {{$post->time}}</p>
+                <label>Datum: {{$post->date}} om {{$post->time}}</label>
+                <br />
                 @if($post->price <= 0)
                     <p>Prijs: Gratis</p>
                 @else
-                    <p>Prijs: €{{number_format($post->price, 2, ',', '')}}<br>
-                        Zie meer informatie voor hoe je kunt betalen.</p>
+                    <p>Prijs: €{{number_format($post->price, 2, ',', '')}}<p>
                 @endif
-                @if($post->bankaccount != null)
-                    <p> Rekeningnummer: {{$post->bankaccount}}
-                @endif
+                
                 <div class="d-flex justify-content-between">
                     <p class="col-sm-8">
                     {!!$post->body!!}

--- a/resources/views/events/index.blade.php
+++ b/resources/views/events/index.blade.php
@@ -20,6 +20,7 @@
                     <td>Titel</td>
                     <td>Datum</td>
                     <td>Tijd</td>
+                    <td>Prijs</td>
                     <td>Beschrijving</td>
                     <td>Groepen</td>
                     <td colspan = 2>Actions</td>
@@ -32,6 +33,7 @@
                         <td>{{$event->title}} </td>
                         <td>{{$event->date}}</td>
                         <td>{{$event->time}}</td>
+                        <td>€{{number_format($event->price, 2, ',', ' ')}}</td>
                         <td>{{$event->body}}</td>
                         <td>
                             @foreach($event->groups as $group)

--- a/resources/views/events/index.blade.php
+++ b/resources/views/events/index.blade.php
@@ -21,6 +21,7 @@
                     <td>Datum</td>
                     <td>Tijd</td>
                     <td>Prijs</td>
+                    <td>Rekeningnummer</td>
                     <td>Beschrijving</td>
                     <td>Groepen</td>
                     <td colspan = 2>Actions</td>
@@ -34,6 +35,7 @@
                         <td>{{$event->date}}</td>
                         <td>{{$event->time}}</td>
                         <td>€{{number_format($event->price, 2, ',', ' ')}}</td>
+                        <td>{{$event->bankaccount}}</td>
                         <td>{{$event->body}}</td>
                         <td>
                             @foreach($event->groups as $group)


### PR DESCRIPTION
# Pull request

Als websitebeheerder wil ik dat de prijs zichtbaar is bij een evenement wanneer van toepassing, zodat de bezoekers van het evenement weten hoeveel het kost

## Summary

er is een prijs en bankrekening nummer toegevoegd, deze zijn niet verplicht en worden alleen getoond wanneer deze zijn ingevuld.

- (Description of the functionality)

prijs en bankrekeningnummer kunnen worden ingevuld wanneer nodig

- (What user story did you complete?)

Acceptatie criteria:

Er moet een voetnoot onder de prijs komen waar staat dat het bedrag overgemaakt moet worden naar het bankrekening nummer van Special Golf

prijs is zichtbaar 

bankrekeningnummer is zichtbaar 

prijs is aanpasbaar

bankrekeningnummer is aanpasbaar

als het evenement gratis is geen bankrekeningnummer

- (All acceptation criteria of the user story)

## Challenges and Solutions

toevoegen en aanpasbaar maken van een rekeningnummer en prijs

- (Image screenshot of UI with description here)
![image](https://user-images.githubusercontent.com/85230291/232207103-a71347fd-2e7b-4941-a38d-c9326b163274.png)
![image](https://user-images.githubusercontent.com/85230291/232207136-db320f34-5db9-481c-b6d5-becc38099ca4.png)
![image](https://user-images.githubusercontent.com/85230291/232207162-0936a4f7-d113-4c21-8bf0-9b8b35636024.png)


## Checklist

- [x] All tests are passed.
- [x] Code compiles.
- [x] No errors in other parts of the program.
- [ ] Code is commented on difficult parts.
- [x] All commits are clearly named.
- [x] Two people are mentioned to review this pull request
- [x] There is a clear description of the functionality and images are added for clarification.
- [x] Hours are registered in Clockify.
- [x] Coding standards have been adhered to.
