### PR TITLE
empty albums are now not visible

### DIFF
--- a/app/Http/Controllers/GalleryController.php
+++ b/app/Http/Controllers/GalleryController.php
@@ -9,7 +9,15 @@ class GalleryController extends Controller
 {
     public function showGallery($year)
     {
-        $albums = Album::with('picture')->where('date', 'LIKE', $year . '%')->get()->sortByDesc('date');
+        //withCount = tel het aantal foto's dat een album heeft en voeg het toe als variable
+        $albums = Album::withCount('picture')->where('date', 'LIKE', $year . '%')->get()->sortByDesc('date');
+
+        foreach ($albums as $key => $album) {
+            if ($album->picture_count <= 0) {
+                //als een album geen foto's heeft, verwijder hem dan uit de $albums array
+                unset($albums[$key]);
+            } 
+        }
 
         return view('Albums.galerijYear', [
             'albums' => $albums,


### PR DESCRIPTION
# Pull request

null

## Summary

### Description

Als een album 0 foto's heeft wordt die nu niet meer weergegeven voor de websitebezoeker

### User story 

S8S-270 Als websitebezoeker wil ik dat lege fotoalbums niet weergegeven worden zodat ik daar niet onnodig op kan klikken.

### List of acceptation criteria

Albums waar geen foto’s aan gekoppeld zijn worden niet weergegeven aan de websitebezoeker

## Challenges and Solutions

### Challenge 1

Ik wist niet hoe je een variable in een array uit diezelfde array haalde in php

### Solution 1

De unset() functie was handig om die variable uit de array te halen

## User Interface

Als je naar de galerij gaat als websitebezoeker zie je nu 1 album voor 2022.
![image](https://user-images.githubusercontent.com/103929631/235951946-fbdfd844-fa8c-4627-8082-eeb89d3f06fe.png)
In de database staan 2 albums voor 2022.
![image](https://user-images.githubusercontent.com/103929631/235952076-2a59eb64-47a3-48a8-95a5-7be994e3622c.png)
Dit komt omdat er geen id van album 3 staat in het pictures tabel.
![image](https://user-images.githubusercontent.com/103929631/235952287-b239e2fa-394e-42b1-b374-05aeb8df057e.png)
Stel, we voegen deze wel toe aan de database:
![image](https://user-images.githubusercontent.com/103929631/235952483-63bc55d0-b7fd-4654-875f-b2da12a54ca5.png)
Wordt die ook weergegeven voor de galerij van 2022.
![image](https://user-images.githubusercontent.com/103929631/235952607-a6de1d8b-ecfc-4430-b1ab-98906bdff910.png)

## Checklist

- [x] All tests are passed.
- [x] Code compiles.
- [x] No errors in other parts of the program.
- [x] Code is commented on difficult parts.
- [x] All commits are clearly named.
- [x] Two people are mentioned to review this pull request
- [x] There is a clear description of the functionality and images are added for clarification.
- [x] Hours are registered in Clockify.
- [x] Coding standards have been adhered to.
