### PR TITLE
fixed layout of team page

### DIFF
--- a/resources/views/members/team.blade.php
+++ b/resources/views/members/team.blade.php
@@ -17,16 +17,16 @@
         @foreach($group->members as $member)
             <div class="col-sm-6">
                 <div class="row">
-                    <p class="col">
-                        {{$member->name}}{{$member->function == '' ? '' : ' - '.$member->function}}<br>
-                        E-mail: {{$member->email}}<br>
-                        {{$member->phonenumber == '' ? '' : 'Mobiel: '.$member->phonenumber}}
-                    </p>
                     @if($member->imgurl != '')
                         <div class="memberimg-box">
                             <img src="{{ asset('storage/img/teammembers/'.$member->imgurl) }}" alt="foto van {{$member->name}}" class="memberimg"/>
                         </div>
                     @endif
+                    <p class="col">
+                        {{$member->name}}{{$member->function == '' ? '' : ' - '.$member->function}}<br>
+                        E-mail: {{$member->email}}<br>
+                        {{$member->phonenumber == '' ? '' : 'Mobiel: '.$member->phonenumber}}
+                    </p>
                 </div>
             </div>
         @endforeach


### PR DESCRIPTION
# Pull request

null

## Summary

### Description

Foto van de persoon staat nu voor de omschrijving en er is geen onnodige whitespace tussen de foto en omschrijving

### User story 

Als websitebeheerder wil ik dat de layout van de team pagina aangepast wordt zodat het overzichtelijker is.

### List of acceptation criteria

Foto’s staan voor de informatie van de desbetreffende persoon

De informatie van een persoon staat direct naast de foto (geen onnodige whitespace)

## Challenges and Solutions

### Challenge 1

was eigenlijk heel makkelijk

### Solution 1

zie bovenstaande

## User Interface

![image](https://user-images.githubusercontent.com/103929631/236201313-4f8e9a36-bc96-4029-8ca7-56001828afdf.png)

## Checklist

- [x] All tests are passed.
- [x] Code compiles.
- [x] No errors in other parts of the program.
- [x] Code is commented on difficult parts.
- [x] All commits are clearly named.
- [x] Two people are mentioned to review this pull request
- [x] There is a clear description of the functionality and images are added for clarification.
- [x] Hours are registered in Clockify.
- [x] Coding standards have been adhered to.
