### PR TITLE
feature/faq titel aanpassen

### DIFF
--- a/app/Http/Controllers/FAQController.php
+++ b/app/Http/Controllers/FAQController.php
@@ -53,7 +53,7 @@ class FAQController extends Controller
 
         FAQ::create(['question' => $attributes['vraag'], 'answer' => $attributes['antwoord']]);
 
-        return redirect('/faq')->with('success', 'Vraag & antwoord opgeslagen.');
+        return redirect('/faq')->with('success', 'Veelgestelde vraag opgeslagen.');
     }
 
     function edit(string $id) {
@@ -70,12 +70,12 @@ class FAQController extends Controller
 
         FAQ::where('id', $id)->update(['question' => $attributes['vraag'], 'answer' => $attributes['antwoord']]);
 
-        return redirect('/faq')->with('success', 'Vraag & antwoord geupdatet.');
+        return redirect('/faq')->with('success', 'Veelgestelde vraag geupdatet.');
     }
 
     function destroy(string $id)
     {
         FAQ::findOrFail($id)->delete();
-        return redirect('/faq')->with('success', 'Vraag & antwoord verwijderd.');
+        return redirect('/faq')->with('success', 'Veelgestelde vraag verwijderd.');
     }
 }

--- a/resources/views/faq/create.blade.php
+++ b/resources/views/faq/create.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.layout')
 
 @section('content')
-<h1 class="display-3">Voeg evenement toe</h1>
+<h1 class="display-3">Veelgestelde vragen toevoegen</h1>
     <a href="/faq" class="btn btn-primary">Ga terug</a>
     <div>
         @if ($errors->any())
@@ -23,7 +23,7 @@
                 <label for="antwoord">Antwoord:</label>
                 <input type="text" class="form-control" name="antwoord" id="antwoord" required/>
             </div>
-            <button type="submit" class="btn btn-primary">Voeg vraag & antwoord toe</button>
+            <button type="submit" class="btn btn-primary">Voeg veelgestelde vraag toe</button>
         </form>
     </div>
 @endsection

--- a/resources/views/faq/edit.blade.php
+++ b/resources/views/faq/edit.blade.php
@@ -1,8 +1,8 @@
 @extends('layouts.layout')
 
 @section('content')
-<h1 class="display-3">FAQ aanpassen
-    <a href="/faq" class="btn btn-primary">Ga terug</a></h1>
+<h1 class="display-3">Veelgestelde vragen aanpassen</h1>
+    <a href="/faq" class="btn btn-primary">Ga terug</a>
 
     @if ($errors->any())
         <div class="alert alert-danger">
@@ -27,6 +27,6 @@
             <input type="text" class="form-control" name="antwoord" value="{{ $FAQ->answer }}" id="antwoord" required/>
         </div>
 
-        <button type="submit" class="btn btn-primary">Update</button>
+        <button type="submit" class="btn btn-primary">Pas veelgestelde vraag aan</button>
     </form>
 @endsection

--- a/resources/views/faq/index.blade.php
+++ b/resources/views/faq/index.blade.php
@@ -2,9 +2,9 @@
 
 @section('content')
 <div class="container">
-<h1 class="display-3">FAQ</h1>
+<h1 class="display-3">Veelgestelde vragen beheren</h1>
     <div>
-        <a href="{{ route('faq.create')}}" class="btn btn-primary mb-3">Creeër nieuwe vraag & antwoord</a>
+        <a href="{{ route('faq.create')}}" class="btn btn-primary mb-3">Creeër nieuwe veelgestelde vraag</a>
     </div>
     @if(session()->get('success'))
         <div class="alert alert-success">

--- a/resources/views/vragenantwoorden.blade.php
+++ b/resources/views/vragenantwoorden.blade.php
@@ -8,7 +8,7 @@
 @endif
 <div class="justify-content-between d-flex">
     <div>
-        <h1 class="display-3">FAQ</h1>
+        <h1>Veelgestelde Vragen</h1>
     </div>
     <div>
     <a href="/vragenantwoorden/vraagformulier" class="btn-primary btn mt-4">Stel een vraag</a>

--- a/tests/Browser/FAQTest.php
+++ b/tests/Browser/FAQTest.php
@@ -25,12 +25,12 @@ class FAQTest extends DuskTestCase
         $this->browse(function (Browser $browser) {
             $browser->loginAs(User::find(1))
                     ->visit('/faq')
-                    ->clickLink("Creeër nieuwe vraag & antwoord")
+                    ->clickLink("Creeër nieuwe veelgestelde vraag")
                     ->type("vraag", "Hoe kan ik het nieuws zien?")
                     ->type("antwoord", "Klik op de 'Nieuws' knop in de menubalk.")
-                    ->press('Voeg vraag & antwoord toe')
+                    ->press('Voeg veelgestelde vraag toe')
                     ->assertPathIs("/faq")
-                    ->assertSee("Vraag & antwoord opgeslagen.");
+                    ->assertSee("Veelgestelde vraag opgeslagen.");
         });
     }
 
@@ -44,10 +44,10 @@ class FAQTest extends DuskTestCase
             }
 
             $browser->visit('/faq')
-                    ->clickLink("Creeër nieuwe vraag & antwoord")
+                    ->clickLink("Creeër nieuwe veelgestelde vraag")
                     ->type("vraag", $string)
                     ->type("antwoord", "Klik op de 'Nieuws' knop in de menubalk.")
-                    ->press('Voeg vraag & antwoord toe')
+                    ->press('Voeg veelgestelde vraag toe')
                     ->assertPathIsNot("/faq")
                     ->assertSee("Vraag mag niet groter zijn dan 255 karakters.");
         });
@@ -63,10 +63,10 @@ class FAQTest extends DuskTestCase
             }
 
             $browser->visit('/faq')
-                    ->clickLink("Creeër nieuwe vraag & antwoord")
+                    ->clickLink("Creeër nieuwe veelgestelde vraag")
                     ->type("vraag", "Hoe kan ik het nieuws zien?")
                     ->type("antwoord", $string)
-                    ->press('Voeg vraag & antwoord toe')
+                    ->press('Voeg veelgestelde vraag toe')
                     ->assertPathIsNot("/faq")
                     ->assertSee("Antwoord mag niet groter zijn dan 999 karakters.");
         });
@@ -76,8 +76,8 @@ class FAQTest extends DuskTestCase
     {
         $this->browse(function (Browser $browser) {
             $browser->visit('/faq')
-                    ->clickLink("Creeër nieuwe vraag & antwoord")
-                    ->press('Voeg vraag & antwoord toe')
+                    ->clickLink("Creeër nieuwe veelgestelde vraag")
+                    ->press('Voeg veelgestelde vraag toe')
                     ->assertPathIsNot("/faq");
         });
     }
@@ -89,9 +89,9 @@ class FAQTest extends DuskTestCase
                     ->clickLink("Aanpassen")
                     ->type("vraag", "Hoe kan ik het nieuws zien?")
                     ->type("antwoord", "Klik op de 'Nieuws' knop in de menubalk.")
-                    ->press('Update')
+                    ->press('Pas veelgestelde vraag aan')
                     ->assertPathIs("/faq")
-                    ->assertSee("Vraag & antwoord geupdatet.");
+                    ->assertSee("Veelgestelde vraag geupdatet.");
         });
     }
 
@@ -109,7 +109,7 @@ class FAQTest extends DuskTestCase
                     ->clickLink("Aanpassen")
                     ->type("vraag", $string)
                     ->type("antwoord", "Klik op de 'Nieuws' knop in de menubalk.")
-                    ->press('Update')
+                    ->press('Pas veelgestelde vraag aan')
                     ->assertPathIsNot("/faq")
                     ->assertSee("Vraag mag niet groter zijn dan 255 karakters.");
         });
@@ -128,7 +128,7 @@ class FAQTest extends DuskTestCase
                     ->clickLink("Aanpassen")
                     ->type("vraag", "Hoe kan ik het nieuws zien?")
                     ->type("antwoord", $string)
-                    ->press('Update')
+                    ->press('Pas veelgestelde vraag aan')
                     ->assertPathIsNot("/faq")
                     ->assertSee("Antwoord mag niet groter zijn dan 999 karakters.");
         });
@@ -141,7 +141,7 @@ class FAQTest extends DuskTestCase
                     ->clickLink("Aanpassen")
                     ->type("vraag", "")
                     ->type("antwoord", "")
-                    ->press('Update')
+                    ->press('Pas veelgestelde vraag aan')
                     ->assertPathIsNot("/faq");
         });
     }
@@ -152,7 +152,7 @@ class FAQTest extends DuskTestCase
             $browser->visit('/faq')
                     ->press("Verwijderen")
                     ->assertPathIs("/faq")
-                    ->assertSee("Vraag & antwoord verwijderd.");
+                    ->assertSee("Veelgestelde vraag verwijderd.");
         });
     }
 
@@ -160,7 +160,7 @@ class FAQTest extends DuskTestCase
     {
         $this->browse(function (Browser $browser) {
             $browser->visit('/faq')
-                    ->clickLink("Creeër nieuwe vraag & antwoord")
+                    ->clickLink("Creeër nieuwe veelgestelde vraag")
                     ->clickLink("Ga terug")
                     ->assertPathIs("/faq");
         });


### PR DESCRIPTION
# Pull request

null

## Summary

### Description

Faq pagina is zodanig veranderd dat alles veranderd is naar 'veelgestelde vragen', zodat het beter te begrijpen is

### User story 

S8S-268 Als websitebeheerder wil ik dat de titel van de FAQ pagina aangepast wordt zodat het een beter beeld geeft van het doel van de pagina

### List of acceptation criteria

De titel van de FAQ pagina is veranderd naar “Veelgestelde vragen aanpassen”

N.B. ik heb voor 'beheren' gekozen omdat aanpassen beter past bij het daadwerkelijk updaten van de veelgestelde vragen

## Challenges and Solutions

### Challenge 1

testen van de FAQ pagina moesten aangepast worden omdat de text veranderd werd

### Solution 1

de text die aangepast was aanpassen in de test

## User Interface

Admin
![image](https://user-images.githubusercontent.com/103929631/236207173-03401c9e-6ea4-4170-a7cd-a0b23a8cbb49.png)
Gebruiker
![image](https://user-images.githubusercontent.com/103929631/236207259-5b3fb12e-94d8-435e-a4cc-73cea856d597.png)

N.B. het aanpassen van de menubalk wordt in de PR van de menubalk revamp afgehandeld.

## Checklist

- [x] All tests are passed.
- [x] Code compiles.
- [x] No errors in other parts of the program.
- [x] Code is commented on difficult parts.
- [x] All commits are clearly named.
- [x] Two people are mentioned to review this pull request
- [x] There is a clear description of the functionality and images are added for clarification.
- [x] Hours are registered in Clockify.
- [x] Coding standards have been adhered to.
