### PR TITLE
feature/mail klikbaar maken

### DIFF
--- a/resources/views/members/team.blade.php
+++ b/resources/views/members/team.blade.php
@@ -18,9 +18,10 @@
             <div class="col-sm-6">
                 <div class="row">
                     <p class="col">
-                        {{$member->name}}{{$member->function == '' ? '' : ' - '.$member->function}}<br>
-                        E-mail: {{$member->email}}<br>
-                        {{$member->phonenumber == '' ? '' : 'Mobiel: '.$member->phonenumber}}
+                        <span>{{$member->name}}{{$member->function == '' ? '' : ' - '.$member->function}}</span><br>
+                        <span>Email:</span>
+                        <a href="mailto:{{$member->email}}" aria-labelledby="Dit is de email van {{$member->name}}">{{$member->email}}</a><br>
+                        <span>{{$member->phonenumber == '' ? '' : 'Mobiel: '.$member->phonenumber}}</span>
                     </p>
                     @if($member->imgurl != '')
                         <div class="memberimg-box">


### PR DESCRIPTION
# Pull request

null

## Summary

### Description

Je kan nu op een email klikken om er direct een mail naar te versturen. ook is de mailto element gelabeled zodat het toegankelijk is

### User story 

Als websitebezoeker wil ik dat de email van een teamlid klikbaar is zodat ik direct een mail aan diegene kan sturen

### List of acceptation criteria

De email bestaat uit een label en link zodat visueel beperkte bezoekers weten wat er staat

De link waar op geklikt kan worden opent direct de mailapplicatie die ingesteld is op de klikker zijn systeem

## Challenges and Solutions

### Challenge 1

Omdat een mail meerdere keren voor kan komen op de team pagina, was een label die gebruik maakt van _unieke_ id's niet goed genoeg.
### Solution 1

dus heb ik een aria-labled-by gebruikt om weer te geven wiens zijn email het is

## User Interface

Zoals je ziet wordt er outlook geopent, omdat bij mij de default mail applicatie outlook is.
![image](https://user-images.githubusercontent.com/103929631/236216889-c076fdac-1618-4bf9-8795-0fce73479253.png)

## Checklist

- [x] All tests are passed.
- [x] Code compiles.
- [x] No errors in other parts of the program.
- [x] Code is commented on difficult parts.
- [x] All commits are clearly named.
- [x] Two people are mentioned to review this pull request
- [x] There is a clear description of the functionality and images are added for clarification.
- [x] Hours are registered in Clockify.
- [x] Coding standards have been adhered to.
