### PR TITLE
gender en golf handicap omgewisseld

### DIFF
--- a/resources/views/events/aanmelden.blade.php
+++ b/resources/views/events/aanmelden.blade.php
@@ -44,6 +44,18 @@
                         @enderror
                     </div>
                     <div>
+                        <label for="golfhandicap" class="col-sm-2 col-form-label">
+                            Golfhandicap
+                        </label>
+                        <div class="col-sm-8">
+                            <input type="text" class="form-control" id="golfhandicap"
+                            placeholder="Vul hier uw golfhandicap(s) in" name="golfhandicap" value="{{old('golfhandicap')}}">
+                        </div>
+                        @error('golfhandicap')
+                        <div class="alert alert-danger">{{ $message }}</div>
+                        @enderror
+                    </div>
+                    <div>
                         <label for="gender" class="col-sm-2 col-form-label">
                             <span class="requiredStar">*</span>Gender
                         </label>
@@ -71,18 +83,6 @@
                             </div>
                         </div>
                         @error('gender')
-                        <div class="alert alert-danger">{{ $message }}</div>
-                        @enderror
-                    </div>
-                    <div>
-                        <label for="golfhandicap" class="col-sm-2 col-form-label">
-                            Golfhandicap
-                        </label>
-                        <div class="col-sm-8">
-                            <input type="text" class="form-control" id="golfhandicap"
-                            placeholder="Vul hier uw golfhandicap(s) in" name="golfhandicap" value="{{old('golfhandicap')}}">
-                        </div>
-                        @error('golfhandicap')
                         <div class="alert alert-danger">{{ $message }}</div>
                         @enderror
                     </div>


### PR DESCRIPTION
# Definition of Done

## Functionele definities 

- [x] De acceptatiecriteria van de user story zijn gehaald. 

- [x] Elk stuk werk is nagekeken door minimaal 2 andere programmeurs. 

- [x] Het programma wordt getest en werkt op 2 verschillende browsers (Google Chrome & Edge). 

### Toegankelijkheid 

- [x] De website moet voor iedereen te navigeren zijn. 

- [x] Inclusief mensen met een beperking. 

- [x] De website dient volledig navigeerbaar te zijn zonder gebruik te maken van een muis. 

- [x] Dit betekent navigeren via de tab en enter toets met behulp van spraak. 

- [x] De knoppen zijn voorzien van duidelijke beschrijvingen. 

- [x] De knoppen zijn groot genoeg om de tekst te bevatten. 

- [x] De teksten op de website bevatten geen spelfouten en zijn duidelijk geformuleerd. 

- [x] Zorg voor voldoende contrast. 

- [x] Contrast wordt getest met deze tool: https://webaim.org/resources/contrastchecker/  

- [x] De WCAG AAA test moet pass teruggeven. 

- [x] Maak geen gebruik van hyperlinks met een klik hier maar gebruik een betekenisvolle beschrijving.  

Zoals: Lees meer over regulering. 

- [x] Maak korte en inhoudelijke pagina’s. 

## Technische definities 

### Reviewers 

- [ ] Elke pull request is door minimaal 2 personen nagekeken. 

- [ ] Een taak wordt pas als af beschouwd zodra hij is goedgekeurd door de 2 reviewers en samengevoegd is op de juiste branch. 

- [ ] De reviewer doorloopt de happy flow. 

- [ ] Hierbij maakt de reviewer gebruik van de juiste werkwijze van de website. 

- [ ] De reviewer probeert d.m.v. onjuist gebruik van de website de website te breken. 

- [ ] Dit kan hij/zij doen door verkeerde invoer van velden. 

- [ ] Views zijn getest op responsiveness (mobiel, tablet, desktop) door middel van UI testen. 

### Ontwikkelaar 

- [x] Er is geen SQL injection mogelijk  

- [x] Alle invoervelden zijn voorzien van een regex. 

- [x] Deze regex zorgt ervoor dat alleen het noodzakelijke ingevoerd kan worden. 

- [x] De coding guidlines zijn aangehouden. 

- [x] De geschreven code compileert. 

- [x] De geschreven code veroorzaakt geen crashes. 

- [x] Code levert geen complicaties op met de AVG-wetgeving. 

- [ ] Dusk tests worden geschreven voor de happy flow en minimaal 1 bad flow. 

- [x] Views zijn getest op responsiveness (mobiel, tablet, desktop) door middel van UI testen. 

- [ ] De siteMap en navigatiebalk zijn geüpdatet op basis van de aanpassingen. 

### Toegankelijkheid 

- [x] Houd je aan de standaarden voor het web. 

- [x] De website moet door gebruik van tab te navigeren zijn. 

- [x] Voeg een alt-tekst toe bij niet-tekstuele-content met betekenisvolle informatie. 

- [x] Maak geen gebruik van spaties. 

- [x] De knoppen hebben een minimaal formaat van 21x30px. 

- [x] Maak gebruik van een rustige layout. 

- [x] Maak gebruik van koppen met h1, h2, h3 tags. 

- [x] Maak gebruik van beschrijvende kopteksten. 

- [x] Duidelijke benaming voor knoppen. 

- [x] Test zelf je code-kwaliteit via www.validator.w3.org  

- [x] Test je syntax. 

- [x] Maak niet alleen gebruik van kleuren om iets duidelijk te maken of uit te leggen maar ook van vormen.  

- [x] Inlaad snelheid zo hoog mogelijk. 

## Summary
Uit de sprint review is duidelijk geworden dat het het aanmeld formulier voor evenementen niet helemaal duidelijk gestructureerd is door de gender en golfhandicap velden om te wisselen is dit nu wel gebeurd

### Description

- (Description of the functionality)

### User story 

S8S-374 Als websitebeheerder wil ik het invulformulier van evenementen aangepast zien zodat het duidelijk is dat ik een golfhandicap in kan vullen

### List of acceptation criteria

Het is duidelijk dat er een invoerveld bij het ‘golfhandicap’ veld hoort.

## Challenges and Solutions

### Challenge 1

- (What was difficult?)

### Solution 1

- (How did you solve it?)

## User Interface
Zoals hieronder zichtbaar zijn gender en golfhandicap omgewisseld van plaats voor meer duidelijkheid

![image](https://github.com/Mees-H/SCRUM-SOp/assets/85230291/4ce25177-6949-4cf4-b0b0-1cd84ee88762)
