### PR TITLE
fixed the appserviceprovider for local/production

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -20,8 +20,14 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        if(env('APP_DEBUG') !== true){
+        if(env('APP_ENV') === 'local') {
+            \URL::forceScheme('http');
+        }
+        else if(env('APP_ENV') === 'production') {
             \URL::forceScheme('https');
+        }
+        else {
+            error_log('Check of de APP_ENV op local of production staat. Run dan het volgende commando: "php artisan optimize:clear" -Mees');
         }
 
         Schema::defaultStringLength(191);


### PR DESCRIPTION
# HOTFIX
## Wat is gefixt?
- De appserviceprovider was alleen ingesteld voor de productieomgeving, nu wordt op basis van de .env file ook de formhandling aagepast (HTTPS of HTTP)
