### PR TITLE
Bugfix/sponsors op event overzicht

### DIFF
--- a/resources/views/events/evenement.blade.php
+++ b/resources/views/events/evenement.blade.php
@@ -85,16 +85,10 @@
                                                      src="{{asset('img/'.$group->imageurl)}}">
                                                 <div class="fullcap text-wrap">
                                                     <div>{{$group->name}}</div>
-                                                    <div>{{$group->zipcode}}, {{$group->city}}</div>
+                                                    <div class="text-center">{{$group->zipcode}}, {{$group->city}}</div>
                                                 </div>
                                             </div>
                                         </a>
-                                        <div class="m-3">
-                                            {{$group->name}}<br>
-                                            {{$group->street}} {{$group->housenumber}}<br>
-                                            {{$group->zipcode}} {{$group->city}}<br>
-                                            <a id="link" href="https://{{$group->link}}">{{$group->link}}</a>
-                                        </div>
                                     @endforeach
                                 </div>
                             </div>


### PR DESCRIPTION
zag er lelijk uit op mobile dus heb de text weggehaald

before:
![afbeelding](https://github.com/Mees-H/SCRUM-SOp/assets/90761435/7d9def1e-a2e7-4203-b63b-091530d2219c)
![afbeelding](https://github.com/Mees-H/SCRUM-SOp/assets/90761435/50ccb026-b7eb-4028-afb8-832b09b2ca13)

after:
![afbeelding](https://github.com/Mees-H/SCRUM-SOp/assets/90761435/3d7b1966-6285-47fd-b04c-d69f6c243ac8)
![afbeelding](https://github.com/Mees-H/SCRUM-SOp/assets/90761435/5d3b30be-f119-428f-b210-135135d493b7)
![afbeelding](https://github.com/Mees-H/SCRUM-SOp/assets/90761435/f28ca76f-70c9-4e50-87c1-ce8a1ed36a8a)
